### PR TITLE
bump dependencies versions

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,12 +1,11 @@
 module github.com/panagiotisptr/cov-diff
 
-go 1.18
-
-require github.com/sourcegraph/go-diff v0.6.1
+go 1.19
 
 require (
-	github.com/actions-go/toolkit v0.0.0-20220621154146-07e42146078c
-	golang.org/x/tools v0.5.0
+	github.com/actions-go/toolkit v0.0.0-20231009202818-7b0d15d26db8
+	github.com/sourcegraph/go-diff v0.7.0
+	golang.org/x/tools v0.14.0
 )
 
 require github.com/google/go-cmp v0.5.8 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/actions-go/toolkit v0.0.0-20220621154146-07e42146078c h1:6OzA7dKDRduEua0ttEWLUgGeP63qRsvhPLfZZlqDSbI=
-github.com/actions-go/toolkit v0.0.0-20220621154146-07e42146078c/go.mod h1:9OsovsbLfu/u3itKgKs36GmT12bRX0Ifg8npKrivnss=
+github.com/actions-go/toolkit v0.0.0-20231009202818-7b0d15d26db8 h1:j34rKTItvvcK+c7NOyjSBys90afz3vVE8VWXvV38Xyw=
+github.com/actions-go/toolkit v0.0.0-20231009202818-7b0d15d26db8/go.mod h1:D5jDCsChxjOG+k+5PGrx0UgXB9U5gCH1ahK/E1q5A/Y=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.8 h1:e6P7q2lk1O+qJJb4BtCQXlK8vWEO8V1ZeuEdJNOqZyg=
@@ -7,10 +7,10 @@ github.com/google/go-cmp v0.5.8/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeN
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/shurcooL/go v0.0.0-20180423040247-9e1955d9fb6e/go.mod h1:TDJrrUr11Vxrven61rcy3hJMUqaf/CLWYhHNPmT14Lk=
 github.com/shurcooL/go-goon v0.0.0-20170922171312-37c2f522c041/go.mod h1:N5mDOmsrJOB+vfqUK+7DmDyjhSLIIBnXo9lvZJj3MWQ=
-github.com/sourcegraph/go-diff v0.6.1 h1:hmA1LzxW0n1c3Q4YbrFgg4P99GSnebYa3x8gr0HZqLQ=
-github.com/sourcegraph/go-diff v0.6.1/go.mod h1:iBszgVvyxdc8SFZ7gm69go2KDdt3ag071iBaWPF6cjs=
-github.com/stretchr/testify v1.7.4 h1:wZRexSlwd7ZXfKINDLsO4r7WBt3gTKONc6K/VesHvHM=
-golang.org/x/tools v0.5.0 h1:+bSpV5HIeWkuvgaMfI3UmKRThoTA5ODJTUd8T17NO+4=
-golang.org/x/tools v0.5.0/go.mod h1:N+Kgy78s5I24c24dU8OfWNEotWjutIs8SnJvn5IDq+k=
+github.com/sourcegraph/go-diff v0.7.0 h1:9uLlrd5T46OXs5qpp8L/MTltk0zikUGi0sNNyCpA8G0=
+github.com/sourcegraph/go-diff v0.7.0/go.mod h1:iBszgVvyxdc8SFZ7gm69go2KDdt3ag071iBaWPF6cjs=
+github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
+golang.org/x/tools v0.14.0 h1:jvNa2pY0M4r62jkRQ6RwEZZyPcymeL9XZMLBbV7U2nc=
+golang.org/x/tools v0.14.0/go.mod h1:uYBEerGOWcJyEORxN+Ek8+TT266gXkNlHdJBwexUsBg=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=


### PR DESCRIPTION
Thank you for such a useful github action!
I tried to use it in my project but there was a warning in job's output:
```
Warning: The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
```

The problem description is [here](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/) but it turns out that toolkit developer has already [dealt with it](https://github.com/actions-go/toolkit/pull/66), so simple dependencies versions upgrade is enough.